### PR TITLE
Sing up and log in

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 db
 target
 *.pem
+jar

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -3,6 +3,29 @@
 version = 3
 
 [[package]]
+name = "actix"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f728064aca1c318585bf4bb04ffcfac9e75e508ab4e8b1bd9ba5dfe04e2cbed5"
+dependencies = [
+ "actix-rt",
+ "bitflags",
+ "bytes",
+ "crossbeam-channel",
+ "futures-core",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+ "log",
+ "once_cell",
+ "parking_lot 0.12.1",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
 name = "actix-codec"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -69,6 +92,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "actix-redis"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38446dc11c743f4f0023b1067c7cfb8f2548f24418e31a193b324e35fa059279"
+dependencies = [
+ "actix",
+ "actix-rt",
+ "actix-service",
+ "actix-tls",
+ "actix-web",
+ "backoff",
+ "derive_more",
+ "futures-core",
+ "log",
+ "redis-async",
+ "time",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
 name = "actix-router"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -118,6 +162,43 @@ dependencies = [
  "futures-core",
  "paste",
  "pin-project-lite",
+]
+
+[[package]]
+name = "actix-session"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43da8b818ae1f11049a4d218975345fe8e56ce5a5f92c11f972abcff5ff80e87"
+dependencies = [
+ "actix",
+ "actix-redis",
+ "actix-service",
+ "actix-utils",
+ "actix-web",
+ "anyhow",
+ "async-trait",
+ "derive_more",
+ "futures-core",
+ "rand",
+ "serde",
+ "serde_json",
+ "tracing",
+]
+
+[[package]]
+name = "actix-tls"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fde0cf292f7cdc7f070803cb9a0d45c018441321a78b1042ffbbb81ec333297"
+dependencies = [
+ "actix-codec",
+ "actix-rt",
+ "actix-service",
+ "actix-utils",
+ "futures-core",
+ "log",
+ "pin-project-lite",
+ "tokio-util",
 ]
 
 [[package]]
@@ -190,6 +271,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "aead"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c192eb8f11fc081b0fe4259ba5af04217d4e0faddd02417310a927911abd7c8"
+dependencies = [
+ "crypto-common",
+ "generic-array",
+]
+
+[[package]]
+name = "aes"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "433cfd6710c9986c576a25ca913c39d66a6474107b406f34f91d4a8923395241"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82e1366e0c69c9f927b1fa5ce2c7bf9eafc8f9268c0b9800729e8b267612447c"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle",
+]
+
+[[package]]
 name = "ahash"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -234,6 +350,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224afbd727c3d6e4b90103ece64b8d1b67fbb1973b1046c2281eed3f3803f800"
+
+[[package]]
+name = "argon2"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db4ce4441f99dbd377ca8a8f57b698c44d0d6e712d8329b5040da5a64aa1ce73"
+dependencies = [
+ "base64ct",
+ "blake2",
+ "password-hash",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -263,12 +396,15 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 name = "backend"
 version = "0.1.0"
 dependencies = [
+ "actix-session",
  "actix-web",
+ "argon2",
  "async-trait",
  "base64 0.21.0",
  "chrono",
  "dotenvy",
  "rand",
+ "rand_core",
  "reqwest",
  "rsa",
  "serde",
@@ -279,10 +415,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "backoff"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1"
+dependencies = [
+ "getrandom",
+ "instant",
+ "rand",
+]
+
+[[package]]
 name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+
+[[package]]
+name = "base64"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ea22880d78093b0cbe17c89f64a7d457941e65759157ec6cb31a31d652b05e5"
 
 [[package]]
 name = "base64"
@@ -301,6 +454,15 @@ name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "blake2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+dependencies = [
+ "digest 0.10.6",
+]
 
 [[package]]
 name = "block-buffer"
@@ -396,6 +558,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cipher"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1873270f8f7942c191139cb8a40fd228da6c3fd2fc376d7e92d47aa14aeb59e"
+dependencies = [
+ "crypto-common",
+ "inout",
+]
+
+[[package]]
 name = "codespan-reporting"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -423,7 +595,14 @@ version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e859cd57d0710d9e06c381b550c06e76992472a8c6d527aecd2fc673dcc231fb"
 dependencies = [
+ "aes-gcm",
+ "base64 0.20.0",
+ "hkdf",
+ "hmac",
  "percent-encoding",
+ "rand",
+ "sha2 0.10.6",
+ "subtle",
  "time",
  "version_check",
 ]
@@ -478,6 +657,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf2b3e8478797446514c91ef04bafcb59faba183e621ad488df88983cc14128c"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-queue"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -503,7 +692,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
+ "rand_core",
  "typenum",
+]
+
+[[package]]
+name = "ctr"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+dependencies = [
+ "cipher",
 ]
 
 [[package]]
@@ -719,6 +918,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-macro"
+version = "0.3.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95a73af87da33b5acf53acfebdc339fe592ecf5357ac7c0a7734ab9d8c876a70"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "futures-sink"
 version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -737,10 +947,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c1d6de3acfef38d2be4b1f543f553131788603495be83da675e180c8d6b7bd1"
 dependencies = [
  "futures-core",
+ "futures-macro",
  "futures-sink",
  "futures-task",
  "pin-project-lite",
  "pin-utils",
+ "slab",
 ]
 
 [[package]]
@@ -762,6 +974,16 @@ dependencies = [
  "cfg-if",
  "libc",
  "wasi",
+]
+
+[[package]]
+name = "ghash"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d930750de5717d2dd0b8c0d42c076c0e884c81a73e6cab859bbd2339c71e3e40"
+dependencies = [
+ "opaque-debug",
+ "polyval",
 ]
 
 [[package]]
@@ -956,6 +1178,15 @@ checksum = "1885e79c1fc4b10f0e172c475f458b7f7b93061064d98c3293e98c5ba0c8b399"
 dependencies = [
  "autocfg",
  "hashbrown",
+]
+
+[[package]]
+name = "inout"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]
@@ -1319,6 +1550,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "password-hash"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7676374caaee8a325c9e7a2ae557f216c5563a171d6997b0ef8a65af35147700"
+dependencies = [
+ "base64ct",
+ "rand_core",
+ "subtle",
+]
+
+[[package]]
 name = "paste"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1380,6 +1622,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
 
 [[package]]
+name = "polyval"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ef234e08c11dfcb2e56f79fd70f6f2eb7f025c0ce2333e82f4f0518ecad30c6"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
+]
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1431,6 +1685,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
+]
+
+[[package]]
+name = "redis-async"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2777130e406c74c28b6cddc0194fcdc2553b5a8795eef9f6384bd3b70a07ba3f"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-sink",
+ "futures-util",
+ "log",
+ "tokio",
+ "tokio-util",
 ]
 
 [[package]]
@@ -2154,6 +2423,16 @@ name = "unicode_categories"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
+
+[[package]]
+name = "universal-hash"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d3160b73c9a19f7e2939a2fdad446c57c1bbbbf4d919d3213ff1267a580d8b5"
+dependencies = [
+ "crypto-common",
+ "subtle",
+]
 
 [[package]]
 name = "untrusted"

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -6,12 +6,15 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+actix-session = { version = "0.7.2", features = ["redis-actor-session"] }
 actix-web = "4.3.1"
+argon2 = "0.4.1"
 async-trait = "0.1.64"
 base64 = "0.21.0"
 chrono = { version = "0.4.23", default-features = false, features = ["clock", "std"] }
 dotenvy = "0.15.6"
 rand = "0.8.5"
+rand_core = { version = "0.6.4", features = ["std"] }
 reqwest = { version = "0.11.14", features = ["json"] }
 rsa = { version = "0.8.1", features = ["sha2"] }
 serde = { version = "1.0.152", features = ["derive"] }

--- a/backend/compose.yaml
+++ b/backend/compose.yaml
@@ -1,5 +1,9 @@
 version: "3.9"
 services:
+  redis:
+    image: redis:7.0.8
+    ports:
+      - 6379:6379
   db:
     image: postgres:15.2
     volumes:

--- a/backend/migrations/20230222011102_init.sql
+++ b/backend/migrations/20230222011102_init.sql
@@ -1,10 +1,10 @@
 CREATE TABLE IF NOT EXISTS "users" (
-    "id" SERIAL PRIMARY KEY,
+    "id" VARCHAR(64) PRIMARY KEY,
     "name" VARCHAR(256) NOT NULL
 );
 
 CREATE TABLE IF NOT EXISTS "user_key_pair" (
-    "user_id" INT PRIMARY KEY,
+    "user_id" VARCHAR(64) PRIMARY KEY,
     "private_key" VARCHAR(4096) NOT NULL,
     "public_key" VARCHAR(4096) NOT NULL,
 

--- a/backend/migrations/20230222011102_init.sql
+++ b/backend/migrations/20230222011102_init.sql
@@ -1,12 +1,13 @@
 CREATE TABLE IF NOT EXISTS "users" (
-    "id" VARCHAR(64) PRIMARY KEY,
-    "name" VARCHAR(256) NOT NULL
+    "id" TEXT PRIMARY KEY,
+    "name" TEXT NOT NULL,
+    "password_hash" TEXT NOT NULL
 );
 
 CREATE TABLE IF NOT EXISTS "user_key_pair" (
-    "user_id" VARCHAR(64) PRIMARY KEY,
-    "private_key" VARCHAR(4096) NOT NULL,
-    "public_key" VARCHAR(4096) NOT NULL,
+    "user_id" TEXT PRIMARY KEY,
+    "private_key" TEXT NOT NULL,
+    "public_key" TEXT NOT NULL,
 
     FOREIGN KEY (user_id) REFERENCES users(id)
 );

--- a/backend/src/error.rs
+++ b/backend/src/error.rs
@@ -5,10 +5,10 @@ use thiserror::Error;
 pub enum ServiceError {
     #[error("The user name is already used.")]
     NameAlreadyTaken,
-    #[error("Unauthorized")]
-    Unauthorized,
     #[error("Invalid ActivityPub request: {0}")]
     InvalidActivityPubRequest(String),
+    #[error("Unauthorized")]
+    Unauthorized,
 
     #[error("Internal server error")]
     InternalServerError,
@@ -23,13 +23,14 @@ pub enum ServiceError {
 impl ResponseError for ServiceError {
     fn status_code(&self) -> reqwest::StatusCode {
         match self {
-            ServiceError::NameAlreadyTaken => reqwest::StatusCode::BAD_REQUEST,
+            ServiceError::NameAlreadyTaken | ServiceError::InvalidActivityPubRequest(_) => {
+                reqwest::StatusCode::BAD_REQUEST
+            }
             ServiceError::Unauthorized => reqwest::StatusCode::UNAUTHORIZED,
-            ServiceError::InvalidActivityPubRequest(_) => reqwest::StatusCode::BAD_REQUEST,
-            ServiceError::InternalServerError => reqwest::StatusCode::INTERNAL_SERVER_ERROR,
-            ServiceError::QueryError(_) => reqwest::StatusCode::INTERNAL_SERVER_ERROR,
-            ServiceError::KeyError(_) => reqwest::StatusCode::INTERNAL_SERVER_ERROR,
-            ServiceError::RequestError(_) => reqwest::StatusCode::INTERNAL_SERVER_ERROR,
+            ServiceError::InternalServerError
+            | ServiceError::QueryError(_)
+            | ServiceError::KeyError(_)
+            | ServiceError::RequestError(_) => reqwest::StatusCode::INTERNAL_SERVER_ERROR,
         }
     }
 

--- a/backend/src/error.rs
+++ b/backend/src/error.rs
@@ -8,6 +8,8 @@ pub enum ServiceError {
     #[error("Invalid ActivityPub request: {0}")]
     InvalidActivityPubRequest(String),
 
+    #[error("Internal server error")]
+    InternalServerError,
     #[error("Query error: {0}")]
     QueryError(#[from] sqlx::Error),
     #[error("Key error: {0}")]
@@ -21,6 +23,7 @@ impl ResponseError for ServiceError {
         match self {
             ServiceError::NameAlreadyTaken => reqwest::StatusCode::BAD_REQUEST,
             ServiceError::InvalidActivityPubRequest(_) => reqwest::StatusCode::BAD_REQUEST,
+            ServiceError::InternalServerError => reqwest::StatusCode::INTERNAL_SERVER_ERROR,
             ServiceError::QueryError(_) => reqwest::StatusCode::INTERNAL_SERVER_ERROR,
             ServiceError::KeyError(_) => reqwest::StatusCode::INTERNAL_SERVER_ERROR,
             ServiceError::RequestError(_) => reqwest::StatusCode::INTERNAL_SERVER_ERROR,

--- a/backend/src/error.rs
+++ b/backend/src/error.rs
@@ -5,6 +5,8 @@ use thiserror::Error;
 pub enum ServiceError {
     #[error("The user name is already used.")]
     NameAlreadyTaken,
+    #[error("Unauthorized")]
+    Unauthorized,
     #[error("Invalid ActivityPub request: {0}")]
     InvalidActivityPubRequest(String),
 
@@ -22,6 +24,7 @@ impl ResponseError for ServiceError {
     fn status_code(&self) -> reqwest::StatusCode {
         match self {
             ServiceError::NameAlreadyTaken => reqwest::StatusCode::BAD_REQUEST,
+            ServiceError::Unauthorized => reqwest::StatusCode::UNAUTHORIZED,
             ServiceError::InvalidActivityPubRequest(_) => reqwest::StatusCode::BAD_REQUEST,
             ServiceError::InternalServerError => reqwest::StatusCode::INTERNAL_SERVER_ERROR,
             ServiceError::QueryError(_) => reqwest::StatusCode::INTERNAL_SERVER_ERROR,

--- a/backend/src/model/key_pair.rs
+++ b/backend/src/model/key_pair.rs
@@ -20,30 +20,20 @@ use crate::error::ServiceError;
 
 #[derive(Clone, Debug)]
 pub struct KeyPair {
-    pub user_id: i32,
+    pub user_id: String,
     pub private_key: String,
     pub public_key: String,
 }
 
 #[async_trait]
 pub trait KeyPairRepository {
-    async fn create_key_pair(
-        &self,
-        user_id: i32,
-        private_key: &str,
-        public_key: &str,
-    ) -> crate::Result<()>;
-    async fn get_key_pair_by_user_id(&self, user_id: i32) -> crate::Result<KeyPair>;
+    async fn save_key_pair(&self, key_pair: KeyPair) -> crate::Result<()>;
+    async fn get_key_pair_by_user_id(&self, user_id: String) -> crate::Result<KeyPair>;
 }
 
 #[async_trait]
 impl KeyPairRepository for PgPool {
-    async fn create_key_pair(
-        &self,
-        user_id: i32,
-        private_key: &str,
-        public_key: &str,
-    ) -> crate::Result<()> {
+    async fn save_key_pair(&self, key_pair: KeyPair) -> crate::Result<()> {
         sqlx::query!(
             r#"
             INSERT INTO user_key_pair ("user_id", "private_key", "public_key")
@@ -53,16 +43,16 @@ impl KeyPairRepository for PgPool {
                 $3
             )
         "#,
-            user_id,
-            private_key,
-            public_key
+            key_pair.user_id,
+            key_pair.private_key,
+            key_pair.public_key
         )
         .execute(self)
         .await?;
         Ok(())
     }
 
-    async fn get_key_pair_by_user_id(&self, user_id: i32) -> crate::Result<KeyPair> {
+    async fn get_key_pair_by_user_id(&self, user_id: String) -> crate::Result<KeyPair> {
         let key_pair = sqlx::query_as!(
             KeyPair,
             r#"

--- a/backend/src/model/user.rs
+++ b/backend/src/model/user.rs
@@ -12,6 +12,7 @@ pub struct User {
 #[async_trait]
 pub trait UserRepository {
     async fn save_user(&self, user: User) -> crate::Result<()>;
+    async fn get_user_by_id(&self, user_id: &str) -> crate::Result<User>;
     async fn get_user_by_name(&self, name: &str) -> crate::Result<User>;
 }
 
@@ -34,6 +35,19 @@ impl UserRepository for PgPool {
         .execute(self)
         .await?;
         Ok(())
+    }
+
+    async fn get_user_by_id(&self, user_id: &str) -> crate::Result<User> {
+        let user = sqlx::query_as!(
+            User,
+            r#"
+            SELECT * FROM users WHERE id = $1
+            "#,
+            user_id
+        )
+        .fetch_one(self)
+        .await?;
+        Ok(user)
     }
 
     async fn get_user_by_name(&self, name: &str) -> crate::Result<User> {

--- a/backend/src/model/user.rs
+++ b/backend/src/model/user.rs
@@ -6,6 +6,7 @@ use sqlx::{FromRow, PgPool};
 pub struct User {
     pub id: String,
     pub name: String,
+    pub password_hash: String,
 }
 
 #[async_trait]
@@ -19,14 +20,16 @@ impl UserRepository for PgPool {
     async fn save_user(&self, user: User) -> crate::Result<()> {
         sqlx::query!(
             r#"
-            INSERT INTO users ("id", "name")
+            INSERT INTO users ("id", "name", "password_hash")
             VALUES (
                 $1,
-                $2
+                $2,
+                $3
             )
             "#,
             user.id,
-            user.name
+            user.name,
+            user.password_hash
         )
         .execute(self)
         .await?;
@@ -56,11 +59,13 @@ mod tests {
         let user = User {
             id: "xxxx".to_string(),
             name: "ikanago".to_string(),
+            password_hash: "password_hashed".to_string(),
         };
         pool.save_user(user).await.unwrap();
 
         let user = pool.get_user_by_name("ikanago").await.unwrap();
         assert_eq!(user.id, "xxxx");
         assert_eq!(user.name, "ikanago");
+        assert_eq!(user.password_hash, "password_hashed");
     }
 }

--- a/backend/src/model/user.rs
+++ b/backend/src/model/user.rs
@@ -63,23 +63,3 @@ impl UserRepository for PgPool {
         Ok(user)
     }
 }
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[sqlx::test]
-    async fn get_registered_user(pool: PgPool) {
-        let user = User {
-            id: "xxxx".to_string(),
-            name: "ikanago".to_string(),
-            password_hash: "password_hashed".to_string(),
-        };
-        pool.save_user(user).await.unwrap();
-
-        let user = pool.get_user_by_name("ikanago").await.unwrap();
-        assert_eq!(user.id, "xxxx");
-        assert_eq!(user.name, "ikanago");
-        assert_eq!(user.password_hash, "password_hashed");
-    }
-}

--- a/backend/src/routes.rs
+++ b/backend/src/routes.rs
@@ -7,7 +7,7 @@ mod user_info;
 mod webfinger;
 
 pub fn routing() -> Scope {
-    web::scope("/")
+    web::scope("")
         .service(self::signup::signup)
         .service(self::user_info::user_info)
         .service(self::inbox::inbox)

--- a/backend/src/routes.rs
+++ b/backend/src/routes.rs
@@ -1,7 +1,9 @@
-use actix_web::{web, Scope};
+use actix_web::{get, web, Responder, Scope};
 
+mod home;
 mod host_meta;
 mod inbox;
+mod login;
 mod signup;
 mod user_info;
 mod webfinger;
@@ -9,8 +11,16 @@ mod webfinger;
 pub fn routing() -> Scope {
     web::scope("")
         .service(self::signup::signup)
+        .service(self::login::login)
+        .service(self::home::home)
         .service(self::user_info::user_info)
         .service(self::inbox::inbox)
         .service(self::webfinger::webfinger)
         .service(self::host_meta::host_meta)
+        .service(ping)
+}
+
+#[get("/ping")]
+async fn ping() -> impl Responder {
+    "pong"
 }

--- a/backend/src/routes/home.rs
+++ b/backend/src/routes/home.rs
@@ -1,0 +1,24 @@
+use actix_session::Session;
+use actix_web::{get, web, HttpResponse, Responder};
+use serde_json::json;
+use sqlx::PgPool;
+
+use crate::{error::ServiceError, model::UserRepository};
+
+#[get("/")]
+pub async fn home(pool: web::Data<PgPool>, session: Session) -> impl Responder {
+    home_service(pool.as_ref(), session).await
+}
+
+async fn home_service(pool: &PgPool, session: Session) -> crate::Result<impl Responder> {
+    // TODO: extract session validation
+    let stored_user_id = session
+        .get::<String>("user_id")
+        .map_err(|_| ServiceError::InternalServerError)?
+        .ok_or(ServiceError::Unauthorized)?;
+    let user = pool.get_user_by_id(&stored_user_id).await.unwrap();
+
+    Ok(HttpResponse::Ok().json(json!({
+        "name": user.name,
+    })))
+}

--- a/backend/src/routes/login.rs
+++ b/backend/src/routes/login.rs
@@ -1,0 +1,52 @@
+use crate::{error::ServiceError, model::UserRepository};
+use actix_session::Session;
+use actix_web::{post, web, HttpResponse, Responder};
+use argon2::{password_hash::Encoding, Argon2, PasswordHash, PasswordVerifier};
+use serde::Deserialize;
+use sqlx::PgPool;
+
+#[derive(Clone, Deserialize)]
+pub struct LoginCredential {
+    pub name: String,
+    pub password: String,
+}
+
+#[post("/login")]
+pub async fn login(
+    pool: web::Data<PgPool>,
+    body: web::Json<LoginCredential>,
+    session: Session,
+) -> crate::Result<impl Responder> {
+    login_service(pool.as_ref(), body.into_inner(), session).await
+}
+
+async fn login_service(
+    pool: &PgPool,
+    LoginCredential { name, password }: LoginCredential,
+    session: Session,
+) -> crate::Result<impl Responder> {
+    let user = pool.get_user_by_name(&name).await.unwrap();
+    verify_password(&password, &user.password_hash)?;
+
+    session.renew();
+    session
+        .insert("user_id", user.id)
+        .expect("user ID is must be serializable");
+    Ok(HttpResponse::Ok().finish())
+}
+
+fn verify_password(password: &str, password_hash: &str) -> crate::Result<()> {
+    let hash = PasswordHash::parse(password_hash, Encoding::default())
+        .map_err(|_| ServiceError::InternalServerError)?;
+    Argon2::default()
+        .verify_password(password.as_bytes(), &hash)
+        .map_err(|_| ServiceError::Unauthorized)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[sqlx::test]
+    async fn invalid_password(pool: PgPool) {}
+}

--- a/backend/src/routes/signup.rs
+++ b/backend/src/routes/signup.rs
@@ -3,7 +3,7 @@ use crate::{
     model::{key_pair::generate_key_pair, KeyPair, KeyPairRepository, User, UserRepository},
 };
 use actix_session::Session;
-use actix_web::{post, web, Responder};
+use actix_web::{post, web, HttpResponse, Responder};
 use argon2::{password_hash::SaltString, Argon2, PasswordHasher};
 use rand::Rng;
 use rand_core::OsRng;
@@ -55,7 +55,7 @@ pub async fn signup_service(
     session
         .insert("user_id", user.id)
         .expect("user ID is must be serializable");
-    Ok(format!("Successfully created user {}", name))
+    Ok(HttpResponse::Ok())
 }
 
 fn generate_id(len: usize) -> String {

--- a/backend/src/routes/user_info.rs
+++ b/backend/src/routes/user_info.rs
@@ -1,5 +1,10 @@
-use crate::model::{KeyPairRepository, UserRepository};
-use actix_web::{get, web, Responder};
+use crate::{
+    error::ServiceError,
+    model::{KeyPairRepository, UserRepository},
+};
+use actix_session::Session;
+use actix_web::{get, web, HttpResponse};
+use reqwest::header::LOCATION;
 use serde_json::json;
 use sqlx::PgPool;
 
@@ -7,13 +12,30 @@ use sqlx::PgPool;
 async fn user_info(
     pool: web::Data<PgPool>,
     host_name: web::Data<String>,
+    session: Session,
     param: web::Path<String>,
-) -> impl Responder {
+) -> crate::Result<HttpResponse> {
+    let stored_user_id = if let Some(user_id) = session
+        .get::<String>("user_id")
+        .map_err(|_| ServiceError::InternalServerError)?
+    {
+        user_id
+    } else {
+        return Ok(HttpResponse::SeeOther()
+            .insert_header((LOCATION, "/login"))
+            .finish());
+    };
+    let user = pool.get_user_by_id(&stored_user_id).await.unwrap();
     let name = param.into_inner();
-    let user = pool.get_user_by_name(&name).await.unwrap();
+    if name != user.name {
+        return Ok(HttpResponse::SeeOther()
+            .insert_header((LOCATION, "/login"))
+            .finish());
+    }
+
     let key_pair = pool.get_key_pair_by_user_id(user.id).await.unwrap();
 
-    web::Json(json!({
+    Ok(HttpResponse::Ok().json(json!({
         "@context": [
             "https://www.w3.org/ns/activitystreams",
             "https://w3id.org/security/v1",
@@ -34,5 +56,5 @@ async fn user_info(
             "owner": format!("https://{}/users/{}", &**host_name, name),
             "publicKeyPem": key_pair.public_key,
         },
-    }))
+    })))
 }


### PR DESCRIPTION
close #6
- Pass entity to repository
- Save hashed password to DB
- Store signed up user id to session
- Test for session
- Change response of /users/{name} according to Access header
- Login and home
- Add test for login
